### PR TITLE
changed from string equivalence to contains to handle subtle differences

### DIFF
--- a/src/test/groovy/com/gebspockproject/template/pages/SampleSecureAreaPage.groovy
+++ b/src/test/groovy/com/gebspockproject/template/pages/SampleSecureAreaPage.groovy
@@ -8,7 +8,7 @@ THIS IS AN EXAMPLE OF A VERY SIMPLE GEB PAGE (LANDING PAGE)
 
 class SampleSecureAreaPage extends Page {
 
-    static at = {  header.text() == "Secure Area" }
+    static at = {  header.text().contains("Secure Area") }
 
     static content= {
 


### PR DESCRIPTION
Safari was having issues with a leading space in the at checker for the Secure Area Page, so just changed it to contains.