### PR TITLE
Update pom and GebConfig to use Webdriver Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Currently the following browsers are supported in this project:
 * `chromeHeadless` - Google Chrome run in headless mode (requires Chrome > 59)
 * `firefox` - Mozilla Firefox (requires Firefox)
 * `firefoxHeadless` - Mozilla Firefox run in headless mode (requires Firefox > 56)
-* `phantomjs` - PhantomJS headless browser (requires PhantomJS)
+* `phantomjs` - PhantomJS headless browser 
 * `safari` - Apple Safari (requires Safari)
 
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ To run the automated tests, execute...
 
 Currently the following browsers are supported in this project:
 * `htmlunit` - the default
-* `chrome` - Google Chrome (requires Chrome and chromedriver)
-* `chromeHeadless` - Google Chrome run in headless mode (requires Chrome > 59 and chromedriver)
-* `firefox` - Mozilla Firefox (requires Firefox and geckodriver)
-* `firefoxHeadless` - Mozilla Firefox run in headless mode (requires Firefox > 56 and geckodriver)
+* `chrome` - Google Chrome (requires Chrome)
+* `chromeHeadless` - Google Chrome run in headless mode (requires Chrome > 59)
+* `firefox` - Mozilla Firefox (requires Firefox)
+* `firefoxHeadless` - Mozilla Firefox run in headless mode (requires Firefox > 56)
 * `phantomjs` - PhantomJS headless browser (requires PhantomJS)
 * `safari` - Apple Safari (requires Safari)
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <htmlunitVersion>2.32.1</htmlunitVersion>
         <phantomjsdriverVersion>1.4.4</phantomjsdriverVersion>
         <safaridriverVersion>3.14.0</safaridriverVersion>
+        <webdrivermanagerVersion>3.0.0</webdrivermanagerVersion>
     </properties>
 
     <build>
@@ -106,14 +107,14 @@
             <artifactId>geb-spock</artifactId>
             <version>${gebVersion}</version>
             <scope>test</scope>
-          </dependency>
-          <dependency>
+        </dependency>
+        <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-server</artifactId>
             <version>${seleniumVersion}</version>
             <scope>test</scope>
-          </dependency>
-          <dependency>
+        </dependency>
+        <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>htmlunit-driver</artifactId>
             <version>${htmlunitVersion}</version>
@@ -147,6 +148,12 @@
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-safari-driver</artifactId>
             <version>${safaridriverVersion}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.github.bonigarcia</groupId>
+            <artifactId>webdrivermanager</artifactId>
+            <version>${webdrivermanagerVersion}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/resources/GebConfig.groovy
+++ b/src/test/resources/GebConfig.groovy
@@ -7,6 +7,7 @@ import org.openqa.selenium.remote.DesiredCapabilities
 import org.openqa.selenium.safari.SafariDriver
 import org.openqa.selenium.chrome.ChromeDriver
 import org.openqa.selenium.chrome.ChromeOptions
+import io.github.bonigarcia.wdm.WebDriverManager;
 
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -22,16 +23,26 @@ Logger.getLogger("org.openqa").setLevel(Level.SEVERE)
 driver = "htmlunit"
 
 //--- GEB ENVIRONMENT OVERRIDES ---//
-
 environments {
 
     //- Set the usual suspects (browsers) using geb shortcuts -//
-    chrome   { driver = "chrome"   }
-    firefox  { driver = "firefox"  }
-    htmlunit { driver = "htmlunit" }
+    htmlunit {
+        driver = "htmlunit"
+    }
 
-    //- Set the other browsers requiring configuration -// 
+    chrome {
+        WebDriverManager.chromedriver().setup()
+        driver = "chrome"
+    }
+
+    firefox {
+        WebDriverManager.firefoxdriver().setup()
+        driver = "firefox"
+    }
+
+    //- Set the other browsers requiring configuration -//
     chromeHeadless {
+        WebDriverManager.chromedriver().setup()
         driver = {
            ChromeOptions o = new ChromeOptions()
            o.addArguments('headless')
@@ -39,6 +50,7 @@ environments {
         }
     }
     firefoxHeadless {
+        WebDriverManager.firefoxdriver().setup()
         driver = {
             FirefoxOptions o = new FirefoxOptions()
             o.addArguments('--headless')
@@ -46,6 +58,7 @@ environments {
         }
     }
     phantomjs {
+        WebDriverManager.phantomjs().setup()
         driver = {
             // Set up the PhantomJS Command Line Arguments to allow for SSL (https sites)
             // This recipe is modified from http://blog.swwomm.com/2014/10/phantomjs-and-ssl.html


### PR DESCRIPTION
Updated project to use [WebDriverManager](https://github.com/bonigarcia/webdrivermanager) for browser drivers such as chromedriver, geckodriver, and phantomjs instead of having to install and configure them on your machine outside of this project. 