### PR TITLE
Update geb 3.3 spock groovy 2.5.10 groovy eclipse

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,81 +8,26 @@
     <version>1</version>
     <name>Sample Login Using Geb Spock</name>
     <properties>
-        <gebVersion>2.2</gebVersion>
+        <gebVersion>3.3</gebVersion>
         <seleniumVersion>3.141.59</seleniumVersion>
-        <groovyVersion>2.4.15</groovyVersion>
+        <groovyVersion>2.5.10</groovyVersion>
         <mavenCompilerVersion>3.7.0</mavenCompilerVersion>
-        <groovyEclipseBatchVersion>2.4.3-01</groovyEclipseBatchVersion>
-        <groovyEclipseCompilerVersion>2.9.2-01</groovyEclipseCompilerVersion>
-        <junitVersion>4.12</junitVersion>
-        <spockCoreVersion>1.1-groovy-2.4</spockCoreVersion>
+        <groovyEclipseBatchVersion>3.0.2-02</groovyEclipseBatchVersion>
+        <groovyEclipseCompilerVersion>3.6.0-03</groovyEclipseCompilerVersion>
+        <junitVersion>4.13</junitVersion>
+        <spockCoreVersion>1.3-groovy-2.5</spockCoreVersion>
         <htmlunitVersion>2.38.0</htmlunitVersion>
         <phantomjsdriverVersion>1.4.4</phantomjsdriverVersion>
         <safaridriverVersion>3.141.59</safaridriverVersion>
         <webdrivermanagerVersion>3.8.1</webdrivermanagerVersion>
     </properties>
 
-    <build>
-        <testSourceDirectory>src/test/groovy</testSourceDirectory>
-        <plugins>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.0</version>
-                <configuration>
-                    <includes>
-                        <include>**/*Spec.*</include>
-                    </includes>
-                    <systemPropertyVariables>
-                        <geb.build.reportsDir>target/test-reports/geb</geb.build.reportsDir>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.groovy</groupId>
-                <artifactId>groovy-eclipse-compiler</artifactId>
-                <version>${groovyEclipseCompilerVersion}</version>
-                <extensions>true</extensions>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.codehaus.groovy</groupId>
-                        <artifactId>groovy-eclipse-batch</artifactId>
-                        <version>${groovyEclipseBatchVersion}</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${mavenCompilerVersion}</version>
-                <configuration>
-                    <compilerId>groovy-eclipse-compiler</compilerId>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <encoding>utf-8</encoding>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.codehaus.groovy</groupId>
-                        <artifactId>groovy-eclipse-compiler</artifactId>
-                        <version>${groovyEclipseCompilerVersion}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.codehaus.groovy</groupId>
-                        <artifactId>groovy-eclipse-batch</artifactId>
-                        <version>${groovyEclipseBatchVersion}</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <version>${groovyVersion}</version>
+            <type>pom</type>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -145,4 +90,68 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <testSourceDirectory>src/test/groovy</testSourceDirectory>
+        <plugins>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M4</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit47</artifactId>
+                        <version>3.0.0-M4</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <includes>
+                        <include>**/*Spec.*</include>
+                    </includes>
+                    <systemPropertyVariables>
+                        <geb.build.reportsDir>target/test-reports/geb</geb.build.reportsDir>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-eclipse-compiler</artifactId>
+                <version>${groovyEclipseCompilerVersion}</version>
+                <extensions>true</extensions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codehaus.groovy</groupId>
+                        <artifactId>groovy-eclipse-batch</artifactId>
+                        <version>${groovyEclipseBatchVersion}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${mavenCompilerVersion}</version>
+                <configuration>
+                    <compilerId>groovy-eclipse-compiler</compilerId>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <encoding>utf-8</encoding>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codehaus.groovy</groupId>
+                        <artifactId>groovy-eclipse-compiler</artifactId>
+                        <version>${groovyEclipseCompilerVersion}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.codehaus.groovy</groupId>
+                        <artifactId>groovy-eclipse-batch</artifactId>
+                        <version>${groovyEclipseBatchVersion}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+
+    </build>
 </project>

--- a/src/test/resources/GebConfig.groovy
+++ b/src/test/resources/GebConfig.groovy
@@ -16,8 +16,8 @@ import java.util.logging.Logger
 // Default Driver is HtmlUnit
 
 // Quiet HTMLUnit warnings
-Logger.getLogger("com.gargoylesoftware.htmlunit").setLevel(Level.SEVERE)
-Logger.getLogger("org.openqa").setLevel(Level.SEVERE)
+Logger logger = Logger.getLogger("");
+logger.setLevel(Level.OFF);
 
 // Set default driver to HtmlUnit
 driver = "htmlunit"


### PR DESCRIPTION
- Geb 3.3
- Spock 1.3-2.5
- Groovy 2.5.10
- Eclipse plug ins latest
- Explicit junit in surefire
- quieter htmlunit logging