### PR TITLE
Added java maven github workflow

### DIFF
--- a/.github/workflows/mvn-cve.yml
+++ b/.github/workflows/mvn-cve.yml
@@ -1,0 +1,26 @@
+name: Check Maven Vulnerabilities
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  dependency-check-maven:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: docker version
+        run: docker --version
+
+      - name: docker-compose version
+        run: docker-compose --version
+
+      - name: pull
+        run: docker-compose -f docker-compose.checks.yml pull
+
+      - name: Run Checks
+        run: docker-compose -f docker-compose.checks.yml run cvescanbrowsertests

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -1,0 +1,28 @@
+name: Run Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  default-chrome:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: docker version
+        run: docker --version
+
+      - name: docker-compose version
+        run: docker-compose --version
+
+      - name: docker-compose pull
+        run: docker-compose pull
+
+      - name: Run Selenium Chrome
+        run: docker-compose run -d seleniumchrome
+
+      - name: Run Tests
+        run: docker-compose run browsertests

--- a/docker-compose.checks.yml
+++ b/docker-compose.checks.yml
@@ -1,0 +1,9 @@
+version: '2.1'
+services:
+  cvescanbrowsertests:
+    build: .
+    container_name: sample-login-geb-spock-tests
+    volumes:
+      - .:/app
+    command: mvn -f /home/app/pom.xml clean verify -DskipTests
+

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
     <name>Sample Login Using Geb Spock</name>
     <properties>
         <mavenCompilerVersion>3.7.0</mavenCompilerVersion>
+        <dependencyCheckMavenVersion>5.3.2</dependencyCheckMavenVersion>
         <groovyEclipseBatchVersion>3.0.2-02</groovyEclipseBatchVersion>
         <groovyEclipseCompilerVersion>3.6.0-03</groovyEclipseCompilerVersion>
         <gebVersion>3.3</gebVersion>
@@ -100,6 +101,21 @@
     <build>
         <testSourceDirectory>src/test/groovy</testSourceDirectory>
         <plugins>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>${dependencyCheckMavenVersion}</version>
+                <configuration>
+                    <failBuildOnCVSS>1</failBuildOnCVSS>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This change set....
 - Adds GitHub Action Check Maven Vulnerabilities to scan for vulnerabilities using the added `dependency-check-maven` plugin
 - Adds Github Action Run Tests which runs this project in a container against the Selenium Standalone Chrome container using the default docker-compose.yml

Note that there are existing vulnerabilities proving that the check will fail.
```
ant-1.9.13.jar (pkg:maven/org.apache.ant/ant@1.9.13, cpe:2.3:a:apache:ant:1.9.13:*:*:*:*:*:*:*) : CVE-2020-1945
testng-6.13.1.jar: jquery-1.7.1.min.js (pkg:javascript/jquery@1.7.1.min) : CVE-2012-6708, CVE-2015-9251, CVE-2019-11358, Regex in its jQuery.htmlPrefilter  sometimes may introduce XSS
```