### PR TITLE
Removed defaulting to html unit if no browser specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ This is a single module maven project which will execute the automated tests.
 To run the automated tests, execute...
 `mvn clean test` *command-line-arguments*
 
-* To run using the default "built in" htmlunit **subset** of tests, execute...  
-`mvn clean test`
+* To run using the "built in" htmlunit **subset** of tests, execute...  
+`mvn clean test -Dgeb.env=htmlunit`
 
 ### To Run the Automated Tests Using Selenium Browser Containers
 The easiest way to run these tests locally is to use Docker and the Selenium Browser Containers.
@@ -72,7 +72,7 @@ The easiest way to run these tests locally is to use Docker and the Selenium Bro
 `-Dgeb.env=chrome`
 
 Currently the following browsers are supported in this project:
-* `htmlunit` - the default
+* `htmlunit` - built-in
 * `dockerChrome` - managed Selenium Chrome Container
 * `dockerFirefox` - managed Selenium Firefox Container
 * `chrome` - Google Chrome (requires Chrome)

--- a/src/test/resources/GebConfig.groovy
+++ b/src/test/resources/GebConfig.groovy
@@ -13,12 +13,13 @@ import io.github.bonigarcia.wdm.WebDriverManager;
 import java.util.logging.Level
 import java.util.logging.Logger
 
-//--- DEFAULT DRIVER ---//
-// Default Driver is HtmlUnit
+//--- DRIVER ---//
 // Quiet HTMLUnit warnings
 Logger logger = Logger.getLogger("");
 logger.setLevel(Level.OFF);
-driver = "htmlunit"
+
+// There is No Default Driver - set as warning
+driver = "THERE IS NO DEFAULT DRIVER, IT MUST BE SPECIFIED"
 
 //--- GEB ENVIRONMENT OVERRIDES ---//
 environments {

--- a/src/test/resources/SpockConfig.groovy
+++ b/src/test/resources/SpockConfig.groovy
@@ -143,7 +143,7 @@ def getSetOfOptionalContextSpecificAnnotationsToExclude() {
     setOfContextSpecificAnnotationsToExclude.addAll(defaultExcludesSet)
 
     // Exclude any recommended tests from running under HtmlUnit which does not support all browser functionality
-    if (isDriverDefaultOrHtmlUnit()) {
+    if (isDriverHtmlUnit()) {
         final htmlUnitExcludesSet = AnnotationsRegistry.getSetOfRecommendedAnnotationsToExcludeUnderHtmlUnit()
         println "[runner] ......set of HtmlUnit context-specific annotations to exclude: [${htmlUnitExcludesSet.join(", ")}]"
         setOfContextSpecificAnnotationsToExclude.addAll(htmlUnitExcludesSet)
@@ -165,10 +165,9 @@ def getSetOfOptionalContextSpecificAnnotationsToExclude() {
 
 
 //--- CONTEXT DETERMINATION METHODS ---//
-boolean isDriverDefaultOrHtmlUnit() {
-    // This assumes that the default driver is HtmlUnit
+boolean isDriverHtmlUnit() {
     final gebEnv = System.getProperty("geb.env")
-    return ( (! gebEnv) || gebEnv.contains("htmlunit") )
+    return ( gebEnv.contains("htmlunit") )
 }
 
 


### PR DESCRIPTION
Removed the defaulting to html unit if no browser is specified i.e. `mvn clean test`.  This eliminates a false successful run if browser specified is invalid.