### PR TITLE
Update Groovy 3 Plus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,10 @@ ARG MAVEN_VERSION=3.6.3
 
 COPY src /home/app/src
 COPY pom.xml /home/app
+COPY groovy-ant-18-suppression.xml /home/app
+
+WORKDIR /home/app
+RUN cd /home/app
 
 # To Run the tests - altho this is orchestrated by the docker-compose.yml file
 # RUN mvn -f /home/app/pom.xml clean test
-

--- a/docker-compose.checks.yml
+++ b/docker-compose.checks.yml
@@ -5,5 +5,4 @@ services:
     container_name: sample-login-geb-spock-tests
     volumes:
       - .:/app
-    command: mvn -f /home/app/pom.xml clean verify -DskipTests
-
+    command: mvn clean verify -DskipTests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     build: .
     container_name: sample-login-geb-spock-tests
     volumes:
-      - .:/app
-    command: mvn -f /home/app/pom.xml clean test -Dgeb.env=seleniumchrome
+      - .:/home/app
+    command: mvn clean test -Dgeb.env=seleniumchrome
     depends_on:
       seleniumchrome:
         condition: service_healthy

--- a/groovy-ant-18-suppression.xml
+++ b/groovy-ant-18-suppression.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+   <suppress>
+      <notes><![CDATA[
+   file name: ant-launcher-1.10.8.jar
+   ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.apache\.ant/ant\-launcher@.*$</packageUrl>
+      <cve>CVE-2020-11979</cve>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+   file name: ant-junit-1.10.8.jar
+   ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.apache\.ant/ant\-junit@.*$</packageUrl>
+      <cve>CVE-2020-11979</cve>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+   file name: ant-antlr-1.10.8.jar
+   ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.apache\.ant/ant\-antlr@.*$</packageUrl>
+      <cpe>cpe:/a:apache:ant</cpe>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+   file name: ant-1.10.8.jar
+   ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.apache\.ant/ant@.*$</packageUrl>
+      <cve>CVE-2020-11979</cve>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+   file name: testng-7.3.0.jar: jquery-3.4.1.min.js
+   ]]></notes>
+      <packageUrl regex="true">^pkg:javascript/jquery@.*$</packageUrl>
+      <cve>CVE-2020-11022</cve>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+   file name: testng-7.3.0.jar: jquery-3.4.1.min.js
+   ]]></notes>
+      <packageUrl regex="true">^pkg:javascript/jquery@.*$</packageUrl>
+      <cve>CVE-2020-11023</cve>
+   </suppress>
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -8,19 +8,20 @@
     <version>1</version>
     <name>Sample Login Using Geb Spock</name>
     <properties>
-        <mavenCompilerVersion>3.7.0</mavenCompilerVersion>
-        <dependencyCheckMavenVersion>5.3.2</dependencyCheckMavenVersion>
-        <groovyEclipseBatchVersion>3.0.2-02</groovyEclipseBatchVersion>
+        <mavenCompilerVersion>3.8.1</mavenCompilerVersion>
+        <mavenSurefirePluginVersion>3.0.0-M5</mavenSurefirePluginVersion>
+        <dependencyCheckMavenVersion>6.0.2</dependencyCheckMavenVersion>
+        <groovyEclipseBatchVersion>3.0.6-01</groovyEclipseBatchVersion>
         <groovyEclipseCompilerVersion>3.6.0-03</groovyEclipseCompilerVersion>
-        <gebVersion>3.3</gebVersion>
-        <spockCoreVersion>1.3-groovy-2.5</spockCoreVersion>
-        <groovyVersion>2.5.10</groovyVersion>
-        <junitVersion>4.13</junitVersion>
+        <gebSpockVersion>3.3</gebSpockVersion>
+        <spockCoreVersion>2.0-M3-groovy-3.0</spockCoreVersion>
+        <groovyVersion>3.0.6</groovyVersion>
         <seleniumVersion>3.141.59</seleniumVersion>
-        <htmlunitVersion>2.38.0</htmlunitVersion>
-        <phantomjsdriverVersion>1.4.4</phantomjsdriverVersion>
         <safaridriverVersion>3.141.59</safaridriverVersion>
-        <webdrivermanagerVersion>3.8.1</webdrivermanagerVersion>
+        <htmlunitVersion>2.44.0</htmlunitVersion>
+        <phantomjsdriverVersion>1.4.4</phantomjsdriverVersion>
+        <testcontainersSeleniumVersion>1.14.3</testcontainersSeleniumVersion>
+        <webdrivermanagerVersion>4.2.2</webdrivermanagerVersion>
     </properties>
 
     <dependencies>
@@ -29,12 +30,6 @@
             <artifactId>groovy-all</artifactId>
             <version>${groovyVersion}</version>
             <type>pom</type>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junitVersion}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.spockframework</groupId>
@@ -51,7 +46,7 @@
         <dependency>
             <groupId>org.gebish</groupId>
             <artifactId>geb-spock</artifactId>
-            <version>${gebVersion}</version>
+            <version>${gebSpockVersion}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -75,7 +70,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>selenium</artifactId>
-            <version>1.13.0</version>
+            <version>${testcontainersSeleniumVersion}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -107,6 +102,10 @@
                 <version>${dependencyCheckMavenVersion}</version>
                 <configuration>
                     <failBuildOnCVSS>1</failBuildOnCVSS>
+                    <skipSystemScope>true</skipSystemScope>
+                    <suppressionFiles>
+                        <suppressionFile>groovy-ant-18-suppression.xml</suppressionFile>
+                    </suppressionFiles>
                 </configuration>
                 <executions>
                     <execution>
@@ -120,14 +119,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M4</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-junit47</artifactId>
-                        <version>3.0.0-M4</version>
-                    </dependency>
-                </dependencies>
+                <version>${mavenSurefirePluginVersion}</version>
                 <configuration>
                     <includes>
                         <include>**/*Spec.*</include>


### PR DESCRIPTION
Update to Groovy 3 plus...
 - updated maven framework and plugins
 - updated (to) groovy 3 spock 2 and geb-spock
 - removed junit (now default junit platform)
 - updated browser drivers etc
 - updated dependency check and testcontainers
 - YUCK, added suppression file for groovy-ant 1.8 CVEs
 - Changed to run container out of the /app (
   project root) directory