### PR TITLE
Update CI Workflows To Use main

### DIFF
--- a/.github/workflows/on_pr_build_push_vet_images.yml
+++ b/.github/workflows/on_pr_build_push_vet_images.yml
@@ -2,8 +2,6 @@ name: Build and Vet
 
 on:
   pull_request:
-    branches:
-      - master
 
 jobs:
 
@@ -91,7 +89,7 @@ jobs:
     name: Promote Vetted Deployment Image
     needs:
       - image-names
-      # - vet-lint-and-dependency-security
+      - vet-dependency-security
       - vet-e2e-tests-deployment
     uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@v0.2.2
     with:

--- a/.github/workflows/on_push_to_main_promote_to_prod.yml
+++ b/.github/workflows/on_push_to_main_promote_to_prod.yml
@@ -2,7 +2,7 @@ name: Promote Branch Image to Production
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 #--- Base Image ---
-# Ruby version must match that in Gemfile.lock
 ARG BASE_IMAGE=maven:3.8-adoptopenjdk-16
 FROM ${BASE_IMAGE} AS maven-jdk
 


### PR DESCRIPTION
# What
This changeset updates the PR and merge workflows to reflect the rename of the default branch to `main`. 

It also resolves a defect where the vetted image was promoted before passing the security scan.

# Why
This is part of the default branch rename and the CI workflows will not run without this update/

# Change Impact Analysis and Testing

- [x] Successful PR Checks verify the changes to that workflow
- [ ] Successful merge checks verify the changes to that workflow (can only be verified on merge)
